### PR TITLE
Use CUDA for audio decoding unless you are on 'mps' and need to use CPU

### DIFF
--- a/examples/generation.py
+++ b/examples/generation.py
@@ -373,7 +373,7 @@ class HiggsAudioModelClient:
         concat_audio_out_ids = torch.concat(audio_out_ids_l, dim=1)
 
         # Fix MPS compatibility: detach and move to CPU before decoding
-        if concat_audio_out_ids.device.type in ["mps", "cuda"]:
+        if concat_audio_out_ids.device.type == "mps":
             concat_audio_out_ids_cpu = concat_audio_out_ids.detach().cpu()
         else:
             concat_audio_out_ids_cpu = concat_audio_out_ids


### PR DESCRIPTION
## Summary
This PR optimizes CUDA performance by removing an unnecessary CPU transfer for audio decoding that was only needed for MPS devices.

Previously, both CUDA and MPS tensors were being moved to CPU for audio decoding. The CPU transfer was only necessary for MPS devices due to embedding operation limitations in quantization layers. This change ensures CUDA tensors remain on GPU for decoding while maintaining MPS compatibility.

## Changes
- Modified the device check in `examples/generation.py` to only move tensors to CPU for MPS devices
- CUDA devices now keep tensors on GPU for audio decoding, improving performance

## Testing
- Maintains existing MPS compatibility 
- Improves performance for CUDA users by avoiding unnecessary GPU->CPU->GPU transfers

Follow-up to address performance optimization opportunity identified in the original MPS compatibility fix.